### PR TITLE
Add method to delete created mappings so they can be flushed

### DIFF
--- a/lib/wiremock_mapper.rb
+++ b/lib/wiremock_mapper.rb
@@ -9,19 +9,50 @@ module WireMockMapper
 
       yield request_builder, response_builder
 
-      send_to_wiremock(url, request: request_builder, response: response_builder)
+      response = send_to_wiremock(url, request: request_builder, response: response_builder)
+      body = JSON.parse(response.body)
+      save_mapping_id(body['id'])
+      body
+    end
+
+    def delete_mappings(url = Configuration.wiremock_url)
+      mapping_ids.each do |mapping_id|
+        delete_from_wiremock(url, mapping_id)
+      end
+
+      forget_saved_mappings
     end
 
     private
 
-    WIREMOCK_NEW_MAPPING_PATH = '__admin/mappings/new'.freeze
+    WIREMOCK_MAPPINGS_PATH = '__admin/mappings'.freeze
+    WIREMOCK_NEW_MAPPING_PATH = "#{WIREMOCK_MAPPINGS_PATH}/new".freeze
 
     def deep_clone(object)
       Marshal.load(Marshal.dump(object))
     end
 
+    def save_mapping_id(mapping_id)
+      mapping_ids << mapping_id
+    end
+
+    def mapping_ids
+      @mapping_ids ||= []
+    end
+
+    def forget_saved_mappings
+      mapping_ids.clear
+    end
+
+    def delete_from_wiremock(url, mapping_id)
+      uri = URI([url, WIREMOCK_MAPPINGS_PATH, mapping_id].join('/'))
+      http = Net::HTTP.new(uri.host, uri.port)
+      request = Net::HTTP::Delete.new(uri.path)
+      http.request(request)
+    end
+
     def send_to_wiremock(url, body)
-      uri = URI(URI.join(url, WIREMOCK_NEW_MAPPING_PATH))
+      uri = URI([url, WIREMOCK_NEW_MAPPING_PATH].join('/'))
       http = Net::HTTP.new(uri.host, uri.port)
       request = Net::HTTP::Post.new(uri.path, 'Content-Type' => 'application/json')
       request.body = body.to_json

--- a/spec/wiremock_mapper_spec.rb
+++ b/spec/wiremock_mapper_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe WireMockMapper do
+  before(:each) { WireMockMapper.send(:forget_saved_mappings) }
   describe 'create_mapping' do
     it 'posts the correct json to the wiremock url' do
       url = 'http://nowhere.com'
@@ -11,7 +12,7 @@ describe WireMockMapper do
                                              { 'matches' => 'some request body' }
                                            ] },
                                 response: { 'body' => 'some response body' } }
-      stub_request(:post, "#{url}/__admin/mappings/new").with(body: expected_request_body)
+      stub_request(:post, "#{url}/__admin/mappings/new").with(body: expected_request_body).to_return(body: '{}')
 
       WireMockMapper.create_mapping(url) do |request, respond|
         request.is_a_post
@@ -34,7 +35,7 @@ describe WireMockMapper do
                                              { 'matches' => 'some request body' }
                                            ] },
                                 response: { 'body' => 'some response body' } }
-      stub_request(:post, "#{url}/__admin/mappings/new").with(body: expected_request_body)
+      stub_request(:post, "#{url}/__admin/mappings/new").with(body: expected_request_body).to_return(body: '{}')
 
       request_builder = WireMockMapper::Builders::RequestBuilder.new.with_header('some_global_header').equal_to('some global header value')
       expect(WireMockMapper::Configuration).to receive(:request_builder).and_return(request_builder)
@@ -49,5 +50,38 @@ describe WireMockMapper do
       end
     end
     # rubocop:enable Metrics/LineLength
+  end
+
+  describe 'delete_mappings' do
+    it 'issues a DELETE for each created mapping' do
+      mapping_id = 'james-james-james'
+      url = 'http://nowhere.com'
+      response_body = { id: mapping_id }.to_json
+      mapping_path = "#{url}/__admin/mappings/#{mapping_id}"
+
+      stub_request(:post, "#{url}/__admin/mappings/new").to_return(body: response_body)
+
+      WireMockMapper.create_mapping(url) {}
+      stub_request(:delete, mapping_path)
+      WireMockMapper.delete_mappings(url)
+
+      assert_requested(:delete, mapping_path)
+    end
+
+    it "does not delete the same mappings once they've been deleted" do
+      mapping_id = 'james-james-james'
+      url = 'http://nowhere.com'
+      response_body = { id: mapping_id }.to_json
+      mapping_path = "#{url}/__admin/mappings/#{mapping_id}"
+
+      stub_request(:post, "#{url}/__admin/mappings/new").to_return(body: response_body)
+
+      WireMockMapper.create_mapping(url) {}
+      stub_request(:delete, mapping_path)
+      WireMockMapper.delete_mappings(url)
+      WireMockMapper.delete_mappings(url)
+
+      assert_requested(:delete, mapping_path, times: 1)
+    end
   end
 end


### PR DESCRIPTION
This should allow one to add WireMockMapper.delete_mappings in a before or after hook in a test suite now.

I also removed URI.join because it didn't work for the case where I needed to join 3 things and it seemed like a bad idea to use it in the other case if it wasn't used in the new method. Generally speaking, URI.join sucks. 

https://gist.github.com/jbrechtel/24aa2cecb208d3d6768e11446e3bc6d8

