### PR TITLE
Added functionality to have wiremock behind authorization

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,6 @@ Style/Documentation:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'rubocop/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task default: [:rubocop, :spec]
+task default: %i[rubocop spec]
 
 RuboCop::RakeTask.new(:rubocop) do |task|
   task.patterns = ['lib/**/*.rb', 'spec/**/*.rb']

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -5,13 +5,14 @@ require_relative 'builders/scenario_builder'
 module WireMockMapper
   class Configuration
     @wiremock_url = ''
+    @wiremock_headers = {}
 
     @request_builder = Builders::RequestBuilder.new
     @response_builder = Builders::ResponseBuilder.new
     @scenario_builder = Builders::ScenarioBuilder.new
 
     class << self
-      attr_reader :request_builder, :response_builder, :wiremock_url, :scenario_builder
+      attr_reader :request_builder, :response_builder, :wiremock_url, :wiremock_headers, :scenario_builder
 
       # Add mappings to include for all future mappings
       def create_global_mapping
@@ -28,6 +29,12 @@ module WireMockMapper
       # @param url [String] the url of the WireMock server
       def set_wiremock_url(url)
         @wiremock_url = url
+      end
+
+      # Set the WireMock headers
+      # @param headers [hash] all the header that we need to set for wiremock
+      def set_wiremock_headers(headers)
+        @wiremock_headers = headers
       end
     end
   end

--- a/lib/wiremock_mapper.rb
+++ b/lib/wiremock_mapper.rb
@@ -40,6 +40,10 @@ module WireMockMapper
     WIREMOCK_CLEAR_MAPPINGS_PATH = "#{WIREMOCK_MAPPINGS_PATH}/reset".freeze
     WIREMOCK_RESET_SCENARIOS_PATH = '__admin/scenarios/reset'.freeze
 
+    def headers
+      { 'Content-Type' => 'application/json' }.merge(Configuration.wiremock_headers)
+    end
+
     def deep_clone(object)
       Marshal.load(Marshal.dump(object))
     end
@@ -48,7 +52,7 @@ module WireMockMapper
       uri = URI([url, WIREMOCK_CLEAR_MAPPINGS_PATH].join('/'))
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true if uri.port == 443
-      request = Net::HTTP::Post.new(uri.path)
+      request = Net::HTTP::Post.new(uri.path, headers)
       http.request(request)
     end
 
@@ -56,7 +60,7 @@ module WireMockMapper
       uri = URI([url, WIREMOCK_MAPPINGS_PATH, mapping_id].join('/'))
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true if uri.port == 443
-      request = Net::HTTP::Delete.new(uri.path)
+      request = Net::HTTP::Delete.new(uri.path, headers)
       http.request(request)
     end
 
@@ -64,7 +68,7 @@ module WireMockMapper
       uri = URI([url, WIREMOCK_MAPPINGS_PATH].join('/'))
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true if uri.port == 443
-      request = Net::HTTP::Post.new(uri.path, 'Content-Type' => 'application/json')
+      request = Net::HTTP::Post.new(uri.path, headers)
       request.body = body.to_json
       http.request(request)
     end
@@ -73,7 +77,7 @@ module WireMockMapper
       uri = URI([url, WIREMOCK_RESET_SCENARIOS_PATH].join('/'))
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true if uri.port == 443
-      request = Net::HTTP::Post.new(uri.path)
+      request = Net::HTTP::Post.new(uri.path, headers)
       http.request(request)
     end
   end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -24,4 +24,11 @@ describe WireMockMapper::Configuration do
       expect(WireMockMapper::Configuration.wiremock_url).to eq('http://whereever.com')
     end
   end
+
+  describe 'wiremock_headers' do
+    it 'sets the wiremock headers' do
+      WireMockMapper::Configuration.set_wiremock_headers({ 'Authorization' => 'Bearer ABC123' })
+      expect(WireMockMapper::Configuration.wiremock_headers).to eq({ 'Authorization' => 'Bearer ABC123' })
+    end
+  end
 end

--- a/spec/wiremock_mapper_spec.rb
+++ b/spec/wiremock_mapper_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe WireMockMapper do
   before(:each) do
     WireMockMapper::Configuration.reset_global_mappings
+    WireMockMapper::Configuration.set_wiremock_headers({})
   end
 
   describe 'create_mapping' do
@@ -29,6 +30,37 @@ describe WireMockMapper do
       end
 
       expect(stub).to have_been_requested
+    end
+
+    it 'posts custom header to the wiremock url' do
+      url = 'http://nowhere.com'
+      expected_request_body = { request: { 'method' => 'POST',
+                                           'url' => '/some/url',
+                                           'headers' => { 'some_global_header' => { 'equalTo' => 'global value' },
+                                                          'some_header' => { 'equalTo' => 'some header value' } },
+                                           'bodyPatterns' => [
+                                             { 'matches' => 'some request body' }
+                                           ] },
+                                response: { 'body' => 'some response body' } }
+
+      stub = stub_request(:post, "#{url}/__admin/mappings").with(body: expected_request_body)
+                                                           .to_return(body: { id: 'whatevs' }.to_json)
+
+      WireMockMapper::Configuration.create_global_mapping do |request|
+        request.with_header('some_global_header').equal_to('global value')
+      end
+
+      WireMockMapper::Configuration.set_wiremock_headers({ 'header1' => 'header-value1' })
+
+      WireMockMapper.create_mapping(url) do |request, respond|
+        request.is_a_post
+               .with_url.equal_to('/some/url')
+               .with_header('some_header').equal_to('some header value')
+               .with_body.matching('some request body')
+        respond.with_body('some response body')
+      end
+
+      expect(stub).to have_requested(:post, "#{url}/__admin/mappings").with(headers: { 'header1' => 'header-value1' })
     end
 
     it 'posts the correct json with configured global mappings to the wiremock url' do
@@ -129,6 +161,19 @@ describe WireMockMapper do
 
       expect(stub).to have_been_requested
     end
+
+    it 'issues a DELETE with custom headers for the supplied mapping id' do
+      mapping_id = 'james-james-james'
+      url = 'http://nowhere.com'
+      stub = stub_request(:delete, "#{url}/__admin/mappings/#{mapping_id}")
+
+      WireMockMapper::Configuration.set_wiremock_headers({ 'header2' => 'header-value2' })
+
+      WireMockMapper.delete_mapping(mapping_id, url)
+
+      expect(stub).to have_requested(:delete, "#{url}/__admin/mappings/#{mapping_id}")
+        .with(headers: { 'header2' => 'header-value2' })
+    end
   end
 
   describe 'clear_mappings' do
@@ -138,6 +183,40 @@ describe WireMockMapper do
       WireMockMapper.clear_mappings(url)
 
       expect(stub).to have_been_requested
+    end
+
+    it 'POSTS with custom headers to the wiremock __admin/mappings/reset path' do
+      url = 'http://nowhere.com'
+      stub = stub_request(:post, "#{url}/__admin/mappings/reset")
+
+      WireMockMapper::Configuration.set_wiremock_headers({ 'header3' => 'header-value3' })
+
+      WireMockMapper.clear_mappings(url)
+
+      expect(stub).to have_requested(:post,
+                                     "#{url}/__admin/mappings/reset").with(headers: { 'header3' => 'header-value3' })
+    end
+  end
+
+  describe 'reset_scenarios' do
+    it 'POSTS to the wiremock __admin/scenarios/reset path' do
+      url = 'http://nowhere.com'
+      stub = stub_request(:post, "#{url}/__admin/scenarios/reset")
+      WireMockMapper.reset_scenarios(url)
+
+      expect(stub).to have_been_requested
+    end
+
+    it 'POSTS with custom headers to the wiremock __admin/scenarios/reset path' do
+      url = 'http://nowhere.com'
+      stub = stub_request(:post, "#{url}/__admin/scenarios/reset")
+
+      WireMockMapper::Configuration.set_wiremock_headers({ 'header3' => 'header-value3' })
+
+      WireMockMapper.reset_scenarios(url)
+
+      expect(stub).to have_requested(:post,
+                                     "#{url}/__admin/scenarios/reset").with(headers: { 'header3' => 'header-value3' })
     end
   end
 end

--- a/wiremock_mapper.gemspec
+++ b/wiremock_mapper.gemspec
@@ -1,8 +1,8 @@
-$LOAD_PATH.unshift(File.expand_path('../lib', __FILE__))
+$LOAD_PATH.unshift(File.expand_path('lib', __dir__))
 
 Gem::Specification.new do |spec|
   spec.name             = 'wiremock_mapper'
-  spec.version          = '2.2.0'
+  spec.version          = '3.0.0'
   spec.platform         = Gem::Platform::RUBY
   spec.required_ruby_version = '>= 2.0.0'
   spec.authors          = ['Isaac Datlof']


### PR DESCRIPTION
We have moved our wiremock instance behind Mashery due to this we cannot use this gem as is. So we modified to have authorization capability to this wiremock_mapper.
 
Updated all the needed methods. Now an optional header can be passed as Authorization header, which will be used to access wiremock instance. 

Also we thought that this is a major change to this gem so gave it a major bump. 

Please review and release this gem so we can continue using this. 