### PR TITLE
Post transformers as array

### DIFF
--- a/lib/builders/response_builder.rb
+++ b/lib/builders/response_builder.rb
@@ -52,7 +52,7 @@ module WireMockMapper
       # @param transformer name [String]
       # @return [ResponseBuilder] response builder for chaining
       def with_transformer(transformer)
-        @options[:transformer] = transformer
+        @options.key?(:transformers) ? @options[:transformers] << transformer : @options[:transformers] = [transformer]
         self
       end
 

--- a/lib/builders/response_builder.rb
+++ b/lib/builders/response_builder.rb
@@ -52,7 +52,8 @@ module WireMockMapper
       # @param transformer name [String]
       # @return [ResponseBuilder] response builder for chaining
       def with_transformer(transformer)
-        @options.key?(:transformers) ? @options[:transformers] << transformer : @options[:transformers] = [transformer]
+        @options[:transformers] ||= []
+        @options[:transformers] << transformer
         self
       end
 

--- a/spec/response_builder_spec.rb
+++ b/spec/response_builder_spec.rb
@@ -60,7 +60,14 @@ describe WireMockMapper::Builders::ResponseBuilder do
     it 'adds the transformer for wiremock to use' do
       builder.with_transformer('optimus prime')
       result = builder.to_hash
-      expect(result[:transformer]).to eq('optimus prime')
+      expect(result[:transformers]).to eq(['optimus prime'])
+    end
+
+    it 'adds multiple transformers for wiremock to use' do
+      builder.with_transformer('optimus prime')
+             .with_transformer('megatron')
+      result = builder.to_hash
+      expect(result[:transformers]).to eq(['optimus prime', 'megatron'])
     end
   end
 end

--- a/spec/wiremock_mapper_spec.rb
+++ b/spec/wiremock_mapper_spec.rb
@@ -15,7 +15,7 @@ describe WireMockMapper do
                                            'bodyPatterns' => [
                                              { 'matches' => 'some request body' }
                                            ] },
-                                response: { 'body' => 'some response body' } }
+                                response: { 'body' => 'some response body', 'transformers' => ['response-template'] } }
 
       stub = stub_request(:post, "#{url}/__admin/mappings").with(body: expected_request_body)
                                                            .to_return(body: { id: 'whatevs' }.to_json)
@@ -27,6 +27,7 @@ describe WireMockMapper do
                .with_body.matching('some request body')
 
         respond.with_body('some response body')
+               .with_transformer('response-template')
       end
 
       expect(stub).to have_been_requested


### PR DESCRIPTION
Post transformers as array as per the wirmock [documentation](https://wiremock.org/docs/response-templating/)